### PR TITLE
Get pinger from checker

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -5,6 +5,7 @@ const defaultName = "healthcheck"
 type Checker interface {
 	Check() error
 	Name() string
+	Pinger() Pinger
 }
 
 func NewChecker(name string, pinger Pinger) Checker {
@@ -35,4 +36,8 @@ func (c *checker) Check() error {
 
 func (c *checker) Name() string {
 	return c.name
+}
+
+func (c *checker) Pinger() Pinger {
+	return c.pinger
 }

--- a/checker_test.go
+++ b/checker_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/music-tribe/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewChecker(t *testing.T) {
@@ -76,4 +78,24 @@ func TestNewChecker(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPinger(t *testing.T) {
+	t.Run("We should get back the correct pinger when requested", func(t *testing.T) {
+		checker := NewChecker("hello", &ShutdownPinger{})
+		pinger := checker.Pinger()
+		require.NotNil(t, pinger)
+		shutdownPinger, ok := pinger.(*ShutdownPinger)
+		assert.True(t, ok)
+		assert.NotNil(t, shutdownPinger)
+	})
+
+	t.Run("We should get back the stub pinger when no pinger is set", func(t *testing.T) {
+		checker := NewChecker("hello", nil)
+		pinger := checker.Pinger()
+		require.NotNil(t, pinger)
+		stubPinger, ok := pinger.(*stubPinger)
+		assert.True(t, ok)
+		assert.NotNil(t, stubPinger)
+	})
 }

--- a/checker_test.go
+++ b/checker_test.go
@@ -40,7 +40,7 @@ func TestNewChecker(t *testing.T) {
 			name: "when the pinger is missing, it should default to the stub pinger",
 			args: args{
 				name:   "hello",
-				pinger: &stubPinger{},
+				pinger: nil,
 			},
 			wantName:       "hello",
 			wantPingErrMsg: stubPingerErrorMessage,


### PR DESCRIPTION
feat: :sparkles: Checker interface should be able to return the Pinger
test: :bug: Fix NewChecker test: `when the pinger is missing, it should default to the stub pinger`