### PR TITLE
refactor: :art: Simplify logger port interface

### DIFF
--- a/checker_shutdown.go
+++ b/checker_shutdown.go
@@ -18,7 +18,7 @@ type ShutdownChecker struct {
 
 func (c *ShutdownChecker) SetShutdown() {
 	c.isShuttingDown.Set(true)
-	c.logger.Info(c.component, "SetShutdown", c.shutdownLog)
+	c.logger.Info(c.shutdownLog)
 }
 
 func (c *ShutdownChecker) Get() *atomic_bool.AtomicBool {

--- a/checker_shutdown_test.go
+++ b/checker_shutdown_test.go
@@ -39,7 +39,7 @@ func TestShutdownChecker_Check(t *testing.T) {
 			shutdownLog := "test service shutting down"
 			p, c := NewShutdownChecker(tt.name, logger, component, shutdownLog)
 			if tt.fields.isShuttingDown {
-				logger.EXPECT().Info(component, "SetShutdown", shutdownLog)
+				logger.EXPECT().Info(shutdownLog)
 				p.SetShutdown()
 			}
 			if err := c.CheckFunc(context.Background()); (err != nil) != tt.wantErr {

--- a/logger.go
+++ b/logger.go
@@ -2,5 +2,5 @@ package healthy
 
 //go:generate mockgen -destination=./mock_logger.go -package=healthy -source=logger.go Logger
 type Logger interface {
-	Info(component, method string, args ...interface{})
+	Info(args ...interface{})
 }

--- a/mock_logger.go
+++ b/mock_logger.go
@@ -34,9 +34,9 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 }
 
 // Info mocks base method.
-func (m *MockLogger) Info(component, method string, args ...interface{}) {
+func (m *MockLogger) Info(args ...interface{}) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{component, method}
+	varargs := []interface{}{}
 	for _, a := range args {
 		varargs = append(varargs, a)
 	}
@@ -44,8 +44,7 @@ func (m *MockLogger) Info(component, method string, args ...interface{}) {
 }
 
 // Info indicates an expected call of Info.
-func (mr *MockLoggerMockRecorder) Info(component, method interface{}, args ...interface{}) *gomock.Call {
+func (mr *MockLoggerMockRecorder) Info(args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{component, method}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), args...)
 }


### PR DESCRIPTION
Change logger port interface to remove `component` and `method` string args for `Info` function

* This simplifies the interface. Component can be defaulted and method can be calculated dynamically using runtime package