### PR TITLE
Alex/propogate errors from health go http handler to echo

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,23 @@
+package healthy
+
+import (
+	"encoding/json"
+
+	"github.com/hellofresh/health-go/v5"
+)
+
+type HealthCheckError struct {
+	Code  int
+	Check health.Check
+}
+
+func NewHealthCheckError(code int, check health.Check) *HealthCheckError {
+	he := &HealthCheckError{Code: code, Check: check}
+	return he
+}
+
+func (he *HealthCheckError) Error() string {
+	byt, _ := json.MarshalIndent(he.Check, "", "  ")
+
+	return string(byt)
+}

--- a/handlers/echo.go
+++ b/handlers/echo.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 
 	health "github.com/hellofresh/health-go/v5"
 	"github.com/labstack/echo/v4"
@@ -10,6 +12,7 @@ import (
 
 // Handler wraps the health-go Handler to be used with Echo.
 // However this doesn't propogate errors up the stack.
+// Use HandlerWithError to propogate errors.
 func Handler(svc healthy.Service) echo.HandlerFunc {
 	opts := make([]health.Config, len(svc.Checkers()))
 
@@ -27,6 +30,29 @@ func Handler(svc healthy.Service) echo.HandlerFunc {
 	h, _ := buildHealthCheckContainer(svc)
 
 	return echo.WrapHandler(h.Handler())
+}
+
+// HandlerWithError wraps the health-go Handler to be used with Echo but propogates errors up the stack.
+// This way echo can handle the error.
+func HandlerWithError(svc healthy.Service) echo.HandlerFunc {
+	// FIXME(alex) check the error here
+	h, _ := buildHealthCheckContainer(svc)
+
+	handlerWithError := func(c echo.Context) error {
+		check := h.Measure(c.Request().Context())
+
+		data, err := json.Marshal(check)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+
+		if check.Status == health.StatusUnavailable {
+			return healthy.NewHealthCheckError(http.StatusServiceUnavailable, check)
+		}
+		return c.JSONBlob(http.StatusOK, data)
+	}
+
+	return handlerWithError
 }
 
 func getCheckFunc(c healthy.Checker) func(ctx context.Context) error {

--- a/handlers/echo.go
+++ b/handlers/echo.go
@@ -8,6 +8,8 @@ import (
 	"github.com/music-tribe/healthy"
 )
 
+// Handler wraps the health-go Handler to be used with Echo.
+// However this doesn't propogate errors up the stack.
 func Handler(svc healthy.Service) echo.HandlerFunc {
 	opts := make([]health.Config, len(svc.Checkers()))
 
@@ -22,14 +24,31 @@ func Handler(svc healthy.Service) echo.HandlerFunc {
 	}
 
 	// FIXME(alex) check the error here
-	h, _ := health.New(health.WithComponent(health.Component{
-		Name:    svc.Name(),
-		Version: svc.Version(),
-	}), health.WithChecks(opts...))
+	h, _ := buildHealthCheckContainer(svc)
 
 	return echo.WrapHandler(h.Handler())
 }
 
 func getCheckFunc(c healthy.Checker) func(ctx context.Context) error {
 	return c.CheckFunc
+}
+
+func buildHealthCheckContainer(svc healthy.Service) (*health.Health, error) {
+	opts := make([]health.Config, len(svc.Checkers()))
+
+	i := 0
+	for name, checker := range svc.Checkers() {
+		opts[i] = health.Config{
+			Name:    name,
+			Check:   getCheckFunc(checker),
+			Timeout: checker.Timeout,
+		}
+		i++
+	}
+
+	h, err := health.New(health.WithComponent(health.Component{
+		Name:    svc.Name(),
+		Version: svc.Version(),
+	}), health.WithChecks(opts...))
+	return h, err
 }

--- a/handlers/echo_test.go
+++ b/handlers/echo_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellofresh/health-go/v5"
+	health "github.com/hellofresh/health-go/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/music-tribe/errors"
 	"github.com/music-tribe/healthy"
@@ -278,6 +278,234 @@ func TestHandler(t *testing.T) {
 		err = json.Unmarshal(body, &healthCheck)
 		require.NoError(t, err)
 		assert.Equal(t, healthCheck.Status, health.Status("Unavailable"))
+		assert.Equal(t, healthCheck.Failures["mockStore"], "Timeout during health check")
+
+		gotStatusCode := rec.Result().StatusCode
+		if err != nil {
+			ce := new(errors.CloudError)
+			if errs.As(err, &ce) {
+				gotStatusCode = ce.StatusCode
+			}
+		}
+
+		if wantStatusCode != gotStatusCode {
+			t.Errorf("wanted status code to be %d but got %d\n", wantStatusCode, gotStatusCode)
+		}
+	})
+}
+
+func TestHandlerWithError(t *testing.T) {
+	e := echo.New()
+
+	// basic custom echo error handler that checks for healthy.HealthCheckError
+	// and reports the health Check back to the client
+	errHandler := func() echo.HTTPErrorHandler {
+		return func(err error, c echo.Context) {
+			healthyErr := &healthy.HealthCheckError{}
+			if errs.As(err, &healthyErr) {
+				// Report error but write the health check response
+				_ = c.JSON(healthyErr.Code, healthyErr.Check)
+				return
+			}
+			// Do something else
+			_ = c.JSON(500, err)
+		}
+	}
+
+	t.Run("When the services are healthy it should return a 200.", func(t *testing.T) {
+		wantStatusCode := 200
+
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		hSvc, _ := healthy.New("some-service", "1.1.3", healthy.NewChecker("mockStore", healthy.NewMockChecker(nil)))
+		h := HandlerWithError(hSvc)
+
+		err := h(ctx)
+		require.NoError(t, err)
+
+		defer rec.Result().Body.Close()
+		body, err := io.ReadAll(rec.Result().Body)
+		require.NoError(t, err)
+
+		healthCheck := health.Check{}
+		err = json.Unmarshal(body, &healthCheck)
+		require.NoError(t, err)
+		assert.Equal(t, healthCheck.Status, health.StatusOK)
+
+		gotStatusCode := rec.Result().StatusCode
+		if err != nil {
+			ce := new(errors.CloudError)
+			if errs.As(err, &ce) {
+				gotStatusCode = ce.StatusCode
+			}
+		}
+
+		if wantStatusCode != gotStatusCode {
+			t.Errorf("wanted status code to be %d but got %d\n", wantStatusCode, gotStatusCode)
+		}
+	})
+
+	t.Run("when we use an echo custom error handler and the services are healthy we should receive a 200 with health check component", func(t *testing.T) {
+		e.HTTPErrorHandler = errHandler()
+
+		wantStatusCode := 200
+
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+
+		hSvc, err := healthy.New("some-service", "v1.1.3", healthy.NewChecker("mockStore", healthy.NewMockChecker(nil)))
+		require.NoError(t, err)
+
+		h := HandlerWithError(hSvc)
+
+		e.GET("/healthz", h)
+		e.ServeHTTP(rec, req)
+
+		defer rec.Result().Body.Close()
+		body, err := io.ReadAll(rec.Result().Body)
+		require.NoError(t, err)
+
+		healthCheck := health.Check{}
+		err = json.Unmarshal(body, &healthCheck)
+		require.NoError(t, err)
+		assert.Equal(t, healthCheck.Status, health.StatusOK)
+		assert.Equal(t, healthCheck.Component.Name, "some-service")
+		assert.Equal(t, healthCheck.Component.Version, "v1.1.3")
+		assert.Nil(t, healthCheck.Failures)
+
+		gotStatusCode := rec.Result().StatusCode
+		if err != nil {
+			ce := new(errors.CloudError)
+			if errs.As(err, &ce) {
+				gotStatusCode = ce.StatusCode
+			}
+		}
+
+		if wantStatusCode != gotStatusCode {
+			t.Errorf("wanted status code to be %d but got %d\n", wantStatusCode, gotStatusCode)
+		}
+	})
+
+	t.Run("when we use an echo custom error handler and the services are unhealthy we should receive the error in the custom error handler", func(t *testing.T) {
+		e.HTTPErrorHandler = errHandler()
+
+		wantStatusCode := 503
+
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+
+		erroringChecker := healthy.NewMockChecker(errors.NewCloudError(404, "")) // no matter what code we pass, it will return a 503 on error
+
+		hSvc, err := healthy.New("some-service", "v1.1.3", healthy.NewChecker("mockStore", erroringChecker))
+		require.NoError(t, err)
+
+		h := HandlerWithError(hSvc)
+
+		e.GET("/healthz", h)
+		e.ServeHTTP(rec, req)
+
+		defer rec.Result().Body.Close()
+		body, err := io.ReadAll(rec.Result().Body)
+		require.NoError(t, err)
+
+		healthCheck := health.Check{}
+		err = json.Unmarshal(body, &healthCheck)
+		require.NoError(t, err)
+		assert.Equal(t, healthCheck.Status, health.StatusUnavailable)
+		assert.Equal(t, healthCheck.Component.Name, "some-service")
+		assert.Equal(t, healthCheck.Component.Version, "v1.1.3")
+		assert.NotNil(t, healthCheck.Failures)
+		assert.NotNil(t, healthCheck.Failures["mockStore"])
+
+		gotStatusCode := rec.Result().StatusCode
+		if err != nil {
+			ce := new(errors.CloudError)
+			if errs.As(err, &ce) {
+				gotStatusCode = ce.StatusCode
+			}
+		}
+
+		if wantStatusCode != gotStatusCode {
+			t.Errorf("wanted status code to be %d but got %d\n", wantStatusCode, gotStatusCode)
+		}
+	})
+
+	t.Run("when we use an echo custom error handler and when one of many services, added in a different order, are unhealthy it should return a 503.", func(t *testing.T) {
+		e.HTTPErrorHandler = errHandler()
+		wantStatusCode := 503
+
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+
+		erroringChecker := healthy.NewMockChecker(errors.NewCloudError(404, "")) // no matter what code we pass, it will return a 503 on error
+
+		hSvc, err := healthy.New(
+			"some-service",
+			"v1.1.3",
+			healthy.NewChecker("mockStoreHealthy", healthy.NewMockChecker(nil)),
+			healthy.NewChecker("mockStoreError", erroringChecker),
+		)
+		require.NoError(t, err)
+
+		h := Handler(hSvc)
+		e.GET("/healthz", h)
+		e.ServeHTTP(rec, req)
+
+		defer rec.Result().Body.Close()
+		body, err := io.ReadAll(rec.Result().Body)
+		require.NoError(t, err)
+
+		healthCheck := health.Check{}
+		err = json.Unmarshal(body, &healthCheck)
+		require.NoError(t, err)
+		assert.Equal(t, healthCheck.Status, health.StatusUnavailable)
+		assert.Equal(t, healthCheck.Component.Name, "some-service")
+		assert.Equal(t, healthCheck.Component.Version, "v1.1.3")
+		assert.NotNil(t, healthCheck.Failures)
+		assert.NotNil(t, healthCheck.Failures["mockStore"])
+
+		gotStatusCode := rec.Result().StatusCode
+		if err != nil {
+			ce := new(errors.CloudError)
+			if errs.As(err, &ce) {
+				gotStatusCode = ce.StatusCode
+			}
+		}
+
+		if wantStatusCode != gotStatusCode {
+			t.Errorf("wanted status code to be %d but got %d\n", wantStatusCode, gotStatusCode)
+		}
+	})
+
+	t.Run("When we pass a checker with timeout we should return a StatusTimeout after the timeout expires", func(t *testing.T) {
+		e.HTTPErrorHandler = errHandler()
+		wantStatusCode := 503
+
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+
+		slowChecker := health.CheckFunc(func(ctx context.Context) error {
+			time.Sleep(time.Second * 2)
+			return nil
+		})
+		hSvc, _ := healthy.New("some-service", "v1.1.3", healthy.NewCheckerWithTimeout("mockStore", slowChecker, 1*time.Second))
+		h := Handler(hSvc)
+		e.GET("/healthz", h)
+		e.ServeHTTP(rec, req)
+
+		defer rec.Result().Body.Close()
+		body, err := io.ReadAll(rec.Result().Body)
+		require.NoError(t, err)
+
+		healthCheck := health.Check{}
+		err = json.Unmarshal(body, &healthCheck)
+		require.NoError(t, err)
+		assert.Equal(t, healthCheck.Status, health.StatusUnavailable)
+		assert.Equal(t, healthCheck.Component.Name, "some-service")
+		assert.Equal(t, healthCheck.Component.Version, "v1.1.3")
+		assert.NotNil(t, healthCheck.Failures)
 		assert.Equal(t, healthCheck.Failures["mockStore"], "Timeout during health check")
 
 		gotStatusCode := rec.Result().StatusCode


### PR DESCRIPTION
Add echo handler wrapper that propagates any health checker errors back up the chain.

This new echo.HandlerWithError function can be used to propagate errors and be caught in an echo custom error handler `HTTPErrorHandler`