### PR TITLE
chore: :arrow_up: Bump go version to 1.24 in github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,14 +12,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
     - name: Install go-sec
       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
     - name: Install go-returns
       run: go install github.com/sqs/goreturns@latest
     - name: Install golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
     - name: Add Go to PATH
       run: echo "PATH=$PATH:/home/runner/go/bin" >> $GITHUB_ENV
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,8 +18,6 @@ jobs:
         go-version: '1.24'
     - name: Install go-sec
       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-    - name: Install go-returns
-      run: go install github.com/sqs/goreturns@latest
     - name: Install golangci-lint
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
     - name: Install staticcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,6 @@ repos:
     - id: go-sec-mod
       args: [ -fmt=junit-xml, -nosec, -out=results_junitxml_gosec.xml, -track-suppressions ]
     - id: go-staticcheck-mod
-    - id: go-returns
-      args: [ -w ]
     - id: golangci-lint-mod
       args: [ --fix, "--out-format=junit-xml:results_junitxml_golangci.xml,colored-line-number" ]
     - id: my-cmd-mod


### PR DESCRIPTION
Requires pre-commit tools upgrading as well.
Removing goreturns from pre-commit